### PR TITLE
Changed config.js permissions to 0600

### DIFF
--- a/build/utils/config.js
+++ b/build/utils/config.js
@@ -29,7 +29,7 @@ export class ConfigManager {
     }
     saveConfig() {
         try {
-            fs.writeFileSync(this.configPath, JSON.stringify(this.config, null, 2));
+            fs.writeFileSync(this.configPath, JSON.stringify(this.config, null, 2), { mode: 0o600 });
         }
         catch (error) {
             console.error('Failed to save config:', error);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -40,7 +40,7 @@ export class ConfigManager {
 
   public saveConfig(): void {
     try {
-      fs.writeFileSync(this.configPath, JSON.stringify(this.config, null, 2));
+      fs.writeFileSync(this.configPath, JSON.stringify(this.config, null, 2), { mode: 0o600 });
     } catch (error) {
       console.error('Failed to save config:', error);
     }


### PR DESCRIPTION
Hello - this PR corrects a security issue in this MCP server that we've mentioned on the [Trail of Bits blog](https://blog.trailofbits.com/2025/04/30/insecure-credential-storage-plagues-mcp/).

Specifically, the file `~/.mcp-figma/config.json` is created with permissions of 0666, meaning that, subject to any custom umask configuration, the user's Figma API credentials are world-readable when the MCP server creates the configuration file.

The file is created with this function call:

`fs.writeFileSync(this.configPath, JSON.stringify(this.config, null, 2));`

If the `mode` option is not specified, the function [`fs.writeFileSync`](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options) uses 0666 permissions for newly created files. Confirmed using Claude Desktop:

```
user@MacBook-Pro mcp-figma % ls -la ~/.mcp-figma
total 8
drwxr-xr-x    3 user  staff    96 Mar 13 19:14 .
drwxr-x---+ 292 user  staff  9344 Apr 29 14:05 ..
-rw-r--r--@   1 user  staff    37 Apr 29 14:06 config.json
```

Replication instructions:

1. Check out the `mcp-figma` repository with `git clone git@github.com:smithery-ai/mcp-figma`.
2. Install dependencies: `cd mcp-figma && npm install`.
3. Edit the `start.sh` file so that the `npm` line reads as follows: `npm --prefix /path/to/mcp-figma run start --silent`.
4. Edit `claude_desktop_config.json` to contain a tool definition like the following:

```
{
  "mcpServers": {
    "figma": {
      "command": "/path/to/mcp-figma/start.sh",
      "args": []
    }
  }
}
```
5. Ensure that there is no existing file at `~/.mcp-figma/config.json`. If one already exists, rename or delete it.
6. Launch Claude Desktop and tell the bot to set your Figma API key to any arbitrary value. Approve the tool call.
7. Check the permissions on `~/.mcp-figma/config.json` and confirm that it's world-readable.